### PR TITLE
Borrow the pkg Field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "bare_err_tree_proc"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "bare_err_tree",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "bare_err_tree"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bare_err_tree_proc",

--- a/bare_err_tree/Cargo.toml
+++ b/bare_err_tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bare_err_tree"
-version = "0.3.3"
+version = "0.4.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/bare_err_tree/Cargo.toml
+++ b/bare_err_tree/Cargo.toml
@@ -24,7 +24,7 @@ eyre = ["dep:eyre"]
 unix_color = []
 
 [dependencies]
-bare_err_tree_proc = { version = "0.2", path = "../bare_err_tree_proc", optional = true }
+bare_err_tree_proc = { version = "0.3", path = "../bare_err_tree_proc", optional = true }
 tracing-error = { version = "0.2", optional = true, default-features = false }
 tracing-core = { version = "0.1", optional = true, default-features = false }
 anyhow = { version = "1", optional = true, default-features = false }

--- a/bare_err_tree/src/lib.rs
+++ b/bare_err_tree/src/lib.rs
@@ -199,7 +199,7 @@ where
 ///         let source = &(&self.source as &dyn Error) as &dyn AsErrTree;
 ///
 ///         // Call the formatting function
-///         (func)(ErrTree::with_pkg(self, &[&[source]], self._pkg.clone()));
+///         (func)(ErrTree::with_pkg(self, &[&[source]], &self._pkg));
 ///     }
 /// }
 ///
@@ -224,7 +224,7 @@ pub struct ErrTree<'a> {
     #[cfg(feature = "source_line")]
     location: Option<&'a Location<'a>>,
     #[cfg(feature = "tracing")]
-    trace: Option<tracing_error::SpanTrace>,
+    trace: Option<&'a tracing_error::SpanTrace>,
 }
 
 impl<'a> ErrTree<'a> {
@@ -236,7 +236,7 @@ impl<'a> ErrTree<'a> {
             not(feature = "source_line"),
             expect(unused, reason = "should be null when no tracking is enabled")
         )]
-        pkg: ErrTreePkg,
+        pkg: &'a ErrTreePkg,
     ) -> Self {
         Self {
             inner,
@@ -244,9 +244,9 @@ impl<'a> ErrTree<'a> {
             #[cfg(feature = "source_line")]
             location: Some(pkg.location),
             #[cfg(all(feature = "tracing", not(feature = "boxed_tracing")))]
-            trace: Some(pkg.trace),
+            trace: Some(&pkg.trace),
             #[cfg(feature = "boxed_tracing")]
-            trace: Some(*pkg.trace),
+            trace: Some(&*pkg.trace),
         }
     }
 
@@ -362,14 +362,14 @@ macro_rules! tree {
         ($func)(bare_err_tree::ErrTree::with_pkg(
             &$inner,
             &[&[ $( &( $x as &dyn core::error::Error ) as &dyn bare_err_tree::AsErrTree , )* ]],
-            $pkg.clone(),
+            &$pkg,
         ))
     };
     ($func:expr, $inner:expr, $pkg:expr, $( $x:expr ),* ) => {
         ($func)(bare_err_tree::ErrTree::with_pkg(
             &$inner,
             &[&[ $( $x as &dyn bare_err_tree::AsErrTree , )* ]],
-            $pkg.clone(),
+            &$pkg,
         ))
     };
 }

--- a/bare_err_tree/src/pkg.rs
+++ b/bare_err_tree/src/pkg.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use core::{cmp::Ordering, fmt::Debug};
+use core::{cmp::Ordering, fmt::Debug, hash::Hash};
 
 #[cfg(feature = "source_line")]
 use core::panic::Location;
@@ -22,7 +22,7 @@ use alloc::boxed::Box;
 /// combinations via feature flags without changing the API.
 ///
 /// All instances of this are considered equal, to avoid infecting sort order
-/// or comparisons between the parent error types.
+/// or comparisons between the parent error types. Hashing is a no-op.
 #[derive(Clone)]
 pub struct ErrTreePkg {
     #[cfg(feature = "source_line")]
@@ -78,4 +78,8 @@ impl PartialOrd for ErrTreePkg {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
+}
+
+impl Hash for ErrTreePkg {
+    fn hash<H: core::hash::Hasher>(&self, _state: &mut H) {}
 }

--- a/bare_err_tree/test_cases/std/Cargo.lock
+++ b/bare_err_tree/test_cases/std/Cargo.lock
@@ -4,14 +4,14 @@ version = 4
 
 [[package]]
 name = "bare_err_tree"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "bare_err_tree_proc",
 ]
 
 [[package]]
 name = "bare_err_tree_proc"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bare_err_tree_proc/Cargo.toml
+++ b/bare_err_tree_proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bare_err_tree_proc"
-version = "0.2.5"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/bare_err_tree_proc/src/errtype.rs
+++ b/bare_err_tree_proc/src/errtype.rs
@@ -151,7 +151,7 @@ impl CollectedErrType {
                 #(#iter_ids,)*
             ];
             let sources = sources.as_slice();
-            (func)(bare_err_tree::ErrTree::with_pkg(self, sources, _err_tree_pkg.clone()))
+            (func)(bare_err_tree::ErrTree::with_pkg(self, sources, _err_tree_pkg))
         }
     }
 
@@ -165,7 +165,7 @@ impl CollectedErrType {
                     let x = &(x #y) as &dyn bare_err_tree::AsErrTree;
                     let x = [x];
                     let x = [x.as_slice()];
-                    (func)(bare_err_tree::ErrTree::with_pkg(self, x.as_slice(), _err_tree_pkg.clone()))
+                    (func)(bare_err_tree::ErrTree::with_pkg(self, x.as_slice(), _err_tree_pkg))
                 },
             }
         };
@@ -183,7 +183,7 @@ impl CollectedErrType {
                             z as &dyn bare_err_tree::AsErrTree
                         ).collect::<alloc::vec::Vec<_>>();
                         let x = [x.as_slice()];
-                        (func)(bare_err_tree::ErrTree::with_pkg(self, x.as_slice(), _err_tree_pkg.clone()))
+                        (func)(bare_err_tree::ErrTree::with_pkg(self, x.as_slice(), _err_tree_pkg))
                     }
                 }
             }
@@ -193,7 +193,7 @@ impl CollectedErrType {
                         let x : [_; #s] = core::array::from_fn(|i| & x [i] #y);
                         let x : [_; #s] = core::array::from_fn(|i| & x [i] as &dyn bare_err_tree::AsErrTree);
                         let x = [x.as_slice()];
-                        (func)(bare_err_tree::ErrTree::with_pkg(self, x.as_slice(), _err_tree_pkg.clone()))
+                        (func)(bare_err_tree::ErrTree::with_pkg(self, x.as_slice(), _err_tree_pkg))
                     }
                 }
             }
@@ -229,7 +229,7 @@ impl CollectedErrType {
                 _ => {
                     let empty = [];
                     let empty = [empty.as_slice()];
-                    (func)(bare_err_tree::ErrTree::with_pkg(self, empty.as_slice(), _err_tree_pkg.clone()))
+                    (func)(bare_err_tree::ErrTree::with_pkg(self, empty.as_slice(), _err_tree_pkg))
                 }
             };
         }

--- a/bare_err_tree_proc/src/lib.rs
+++ b/bare_err_tree_proc/src/lib.rs
@@ -463,7 +463,7 @@ fn err_tree_struct(
                 impl #impl_generics bare_err_tree::AsErrTree for #ident #ty_generics #where_clause {
                     #[track_caller]
                     fn as_err_tree(&self, func: &mut dyn FnMut(bare_err_tree::ErrTree<'_>)) {
-                        let _err_tree_pkg = self.#field_ident .clone();
+                        let _err_tree_pkg = &self.#field_ident;
                         #sources
                     }
                 }
@@ -498,7 +498,7 @@ fn err_tree_struct(
                 impl #impl_generics bare_err_tree::AsErrTree for #ident #ty_generics #where_clause {
                     #[track_caller]
                     fn as_err_tree(&self, func: &mut dyn FnMut(bare_err_tree::ErrTree<'_>)) {
-                        let _err_tree_pkg = self.#prev_len .clone();
+                        let _err_tree_pkg = &self.#prev_len;
                         #sources
                     }
                 }
@@ -540,7 +540,7 @@ fn err_tree_struct(
                 impl #impl_generics bare_err_tree::AsErrTree for #ident #ty_generics #where_clause {
                     #[track_caller]
                     fn as_err_tree(&self, func: &mut dyn FnMut(bare_err_tree::ErrTree<'_>)) {
-                        let _err_tree_pkg = self.#field_ident .clone();
+                        let _err_tree_pkg = &self.#field_ident;
                         #sources
                     }
                 }


### PR DESCRIPTION
Replaces `pkg.clone()` with `&pkg` when formatting error trees. Very minor difference, but potentially skips a heap allocation and/or shrinks stack usage of error tree printing. The extra redirect is anticipated to be a very minor cost, especially when it saves a clone.