### PR TITLE
Improve Internals, Add Public Docs

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -71,8 +71,8 @@ jobs:
     - uses: taiki-e/install-action@cargo-hack
 
     - run: |
-        cargo hack --each-feature build --ignore-private
-        cargo hack --each-feature test --ignore-private --no-run 
+        cargo hack --each-feature build --ignore-private --frozen
+        cargo hack --each-feature test --ignore-private --no-run --frozen 
 
   # From https://doc.rust-lang.org/cargo/guide/continuous-integration.html#verifying-rust-version
   # See https://crates.io/crates/cargo-hack
@@ -98,7 +98,7 @@ jobs:
     - name: Test for MSRV in Cargo.toml
       run: |
         VERSION="$(cargo metadata --format-version 1 | jq '.packages | .[] | select(.name == "bare_err_tree")| .rust_version' | tr -d '"')"
-        cargo hack check --version-range "$VERSION" --all-targets --all-features --ignore-private
+        cargo hack check --version-range "$VERSION" --all-targets --all-features --ignore-private --frozen
 
   test:
     strategy:
@@ -127,7 +127,7 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2
 
-    - run: cargo test --verbose --all-features
+    - run: cargo test --verbose --all-features --frozen
 
   test-feature-powerset:
     runs-on: ubuntu-latest
@@ -142,5 +142,4 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - uses: taiki-e/install-action@cargo-hack
 
-    - run: cargo hack test --feature-powerset --skip default,boxed,anyhow,eyre,unix_color
-
+    - run: cargo hack test --feature-powerset --skip default,boxed,anyhow,eyre,unix_color --frozen

--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -71,8 +71,8 @@ jobs:
     - uses: taiki-e/install-action@cargo-hack
 
     - run: |
-        cargo hack --each-feature build --ignore-private --frozen
-        cargo hack --each-feature test --ignore-private --no-run --frozen 
+        cargo hack --each-feature build --ignore-private --locked
+        cargo hack --each-feature test --ignore-private --no-run --locked 
 
   # From https://doc.rust-lang.org/cargo/guide/continuous-integration.html#verifying-rust-version
   # See https://crates.io/crates/cargo-hack
@@ -98,7 +98,7 @@ jobs:
     - name: Test for MSRV in Cargo.toml
       run: |
         VERSION="$(cargo metadata --format-version 1 | jq '.packages | .[] | select(.name == "bare_err_tree")| .rust_version' | tr -d '"')"
-        cargo hack check --version-range "$VERSION" --all-targets --all-features --ignore-private --frozen
+        cargo hack check --version-range "$VERSION" --all-targets --all-features --ignore-private --locked
 
   test:
     strategy:
@@ -127,7 +127,7 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2
 
-    - run: cargo test --verbose --all-features --frozen
+    - run: cargo test --verbose --all-features --locked
 
   test-feature-powerset:
     runs-on: ubuntu-latest
@@ -142,4 +142,4 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - uses: taiki-e/install-action@cargo-hack
 
-    - run: cargo hack test --feature-powerset --skip default,boxed,anyhow,eyre,unix_color --frozen
+    - run: cargo hack test --feature-powerset --skip default,boxed,anyhow,eyre,unix_color --locked

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# bare\_err\_tree Contributing
+Contributions to this library are welcome!
+See the [policies][Readme] for consumer facing rules.
+
+## How
+Communicate over GitHub issues and pull requests.
+Draft pull requests are suggested to claim and avoid duplication of work.
+Usually, you will want to open an issue first for discussion.
+
+### CI
+There are automated tests on GitHub CI that must be passed before merge.
+They are intended to be comprehensive (feel free to contribute more tests).
+Code coverage is for reviewer information, not a guideline.
+
+## Style
+Standard clippy lints are used.
+Code should be clear to read and documented as appropriate both internally and
+externally.
+Specific standards are loose -- don't bother documenting getters.
+
+## Dependencies
+Default dependencies are deliberately minimal.
+Any dependencies that are introduced should be specified as a major version.
+Non-optional dependencies must provide necessary functionality for the library
+that cannot be easily written into this library itself (e.g. requires unsafe
+code blocks).
+Optional dependencies for a feature such as `tracing` should still be
+minimized.
+
+## Public Documentation
+All features should be documented in the [library root][clib].
+Downstream users should be able to use this library by looking only at the
+rustdocs, without any knowledge of the source code.
+
+## Licensing
+This library is licensed under MPL 2.0.
+The license header must be on all source files.
+
+## Forking
+Ideally all debate can come to a reasonable consensus, but forking a new
+project from this is encouraged if there is an intractable disagreement.
+
+[Policies]: README.md#Policies
+[clib]: bare_err_tree/src/lib.rs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # bare\_err\_tree Contributing
 Contributions to this library are welcome!
-See the [policies][Readme] for consumer facing rules.
+See the [policies][Policies] for consumer facing rules.
 
 ## How
 Communicate over GitHub issues and pull requests.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "bare_err_tree"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bare_err_tree_proc",

--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ The JSON output heavily repeats keys and does not deduplicate traces: compressio
 The formatting is borrowed from from [error-stack][ErrorStack].
 Please see the [contributors page](https://github.com/hashintel/hash/graphs/contributors) for appropriate credit.
 
+# Policies
+See [CONTRIBUTING.md][Contributing] for development specific guidance/rules.
+
+## No std/alloc Core
+The library, built with default features, never uses `extern crate std` or `extern crate alloc`.
+Any features that enable either note this in the [crate root][clib].
+
+## Version Compatibility
+[Semantic versioning][https://semver.org/] is accurately followed.
+Libraries are expected to use depend on the major release (e.g. `version = "1"`)
+with at most the default features.
+This allows binaries to unify and control the `bare_err_tree` feature flags for
+all their dependencies.
+New features are a minor release.
+
+## MSRV
+The `rust-version` is specified in the workspace [Cargo.toml][ctoml] and must be accurate. It can be bumped up to the latest standard rust version whenever a feature is useful. Utilize [Cargo dependecy resolution][cdeps] if you use this library
+
 # Example Output (source\_line)
 Generate with `cd bare_err_tree/test_cases/std; cargo run --bin example`.
 ```
@@ -115,6 +133,12 @@ Generate with `cd bare_err_tree/test_cases/json; cargo run --bin example`.
 [Docs]: https://bennett-petzold.github.io/bare_err_tree/docs/bare_err_tree/
 [Coverage]: https://bennett-petzold.github.io/bare_err_tree/coverage/badge.svg
 [CoveragePages]: https://bennett-petzold.github.io/bare_err_tree/coverage/
+
+[Contributing]: CONTRIBUTING.md
+[ctoml]: Cargo.toml
+[cdeps]: https://doc.rust-lang.org/cargo/reference/resolver.html
+[clib]: bare_err_tree/src/lib.rs
+[semver]: https://semver.org/
 
 [ErrorStack]: https://crates.io/crates/error-stack
 [Eyre]: https://crates.io/crates/eyre

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The library, built with default features, never uses `extern crate std` or `exte
 Any features that enable either note this in the [crate root][clib].
 
 ## Version Compatibility
-[Semantic versioning][https://semver.org/] is accurately followed.
+[Semantic versioning][semver] is accurately followed.
 Libraries are expected to use depend on the major release (e.g. `version = "1"`)
 with at most the default features.
 This allows binaries to unify and control the `bare_err_tree` feature flags for

--- a/bare_err_tree/Cargo.toml
+++ b/bare_err_tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bare_err_tree"
-version = "0.6.0"
+version = "0.6.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/bare_err_tree/src/json.rs
+++ b/bare_err_tree/src/json.rs
@@ -2,7 +2,7 @@
 
 use core::{
     borrow::Borrow,
-    fmt::{self, Formatter, Write},
+    fmt::{self, Write},
     iter::FusedIterator,
     str::Chars,
 };
@@ -154,7 +154,7 @@ where
     S: AsRef<str>,
     F: fmt::Write,
 {
-    fmt_tree::<FRONT_MAX, _>(JsonReconstruct::new(json.as_ref()), formatter)
+    fmt_tree::<FRONT_MAX, _, _>(JsonReconstruct::new(json.as_ref()), formatter)
 }
 
 const EMPTY_STR: &str = "";
@@ -243,7 +243,7 @@ impl<'f> JsonReconstruct<'f> {
 }
 
 impl<'f> ErrTreeFormattable for JsonReconstruct<'f> {
-    fn apply_msg(&self, f: &mut dyn fmt::Write) -> fmt::Result {
+    fn apply_msg<W: fmt::Write + ?Sized>(&self, f: &mut W) -> fmt::Result {
         apply_json_str(self.msg, f)
     }
 
@@ -281,7 +281,7 @@ impl<'f> ErrTreeFormattable for JsonReconstruct<'f> {
         !self.source_line.is_empty()
     }
     #[cfg(feature = "source_line")]
-    fn apply_source_line(&self, f: &mut dyn fmt::Write) -> fmt::Result {
+    fn apply_source_line<W: fmt::Write + ?Sized>(&self, f: &mut W) -> fmt::Result {
         apply_json_str(self.source_line, f)
     }
 

--- a/bare_err_tree/src/json.rs
+++ b/bare_err_tree/src/json.rs
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 //! Error tree output to/from JSON.
 
 use core::{

--- a/bare_err_tree/src/lib.rs
+++ b/bare_err_tree/src/lib.rs
@@ -187,7 +187,7 @@ where
 {
     let mut res = Ok(());
     tree.as_err_tree(&mut |tree| {
-        res = write!(formatter, "{}", ErrTreeFmtWrap::<FRONT_MAX, _>::new(tree));
+        res = fmt_tree::<FRONT_MAX, _>(tree, &mut formatter);
     });
     res
 }

--- a/bare_err_tree/src/lib.rs
+++ b/bare_err_tree/src/lib.rs
@@ -187,7 +187,7 @@ where
 {
     let mut res = Ok(());
     tree.as_err_tree(&mut |tree| {
-        res = fmt_tree::<FRONT_MAX, _>(tree, &mut formatter);
+        res = fmt_tree::<FRONT_MAX, _, _>(tree, &mut formatter);
     });
     res
 }

--- a/bare_err_tree/src/pkg.rs
+++ b/bare_err_tree/src/pkg.rs
@@ -30,8 +30,10 @@ use alloc::boxed::Box;
 #[derive(Clone)]
 pub struct ErrTreePkg {
     #[cfg(not(feature = "boxed"))]
+    #[allow(dead_code)]
     inner: InnerErrTreePkg,
     #[cfg(feature = "boxed")]
+    #[allow(dead_code)]
     inner: Box<InnerErrTreePkg>,
 }
 


### PR DESCRIPTION
Modifies the non-panic print to operate on a `fmt::Write` directly, instead of going through a format method. Also allows for specialization in those formatting calls (the previous behavior can be replicated by passing in `&dyn fmt::Write`).

Adds public standards and contributing guidelines to documentation.