### PR TITLE
Add Unsafe For AsErrTree Wrap

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -25,12 +25,21 @@ jobs:
         components: llvm-tools-preview
     - uses: Swatinem/rust-cache@v2
     - uses: taiki-e/install-action@cargo-llvm-cov
+    - uses: taiki-e/install-action@cargo-hack
 
     - name: Regular Tests
-      run: TRYBUILD=overwrite cargo llvm-cov test --no-report --tests --all-features
+      run: |
+        TRYBUILD=overwrite cargo hack llvm-cov test \
+          --feature-powerset \
+          --skip default,boxed,anyhow,eyre,unix_color,tracing \
+          --locked --no-report --tests
 
     - name: Doc Tests
-      run: TRYBUILD=overwrite cargo llvm-cov test --no-report --doc --all-features
+      run: |
+        TRYBUILD=overwrite cargo hack llvm-cov test \
+          --feature-powerset \
+          --skip default,boxed,anyhow,eyre,unix_color,tracing \
+          --locked --no-report --doc
 
     - name: Coverage Report
       run: cargo llvm-cov report --doctests --cobertura > coverage.xml

--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -143,3 +143,23 @@ jobs:
     - uses: taiki-e/install-action@cargo-hack
 
     - run: cargo hack test --feature-powerset --skip default,boxed,anyhow,eyre,unix_color --locked
+
+  test-feature-powerset-miri:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    environment:
+      name: ${{ github.ref_name != 'main' && 'testing' || 'unrestricted' }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: Swatinem/rust-cache@v2
+    - name: Install Miri
+      run: |
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
+          cargo miri setup
+    - uses: taiki-e/install-action@cargo-hack
+
+    - run: cargo hack miri test --feature-powerset --skip default,boxed,anyhow,eyre,unix_color,tracing --locked

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -69,12 +69,21 @@ jobs:
         components: llvm-tools-preview
     - uses: Swatinem/rust-cache@v2
     - uses: taiki-e/install-action@cargo-llvm-cov
+    - uses: taiki-e/install-action@cargo-hack
 
     - name: Regular Tests
-      run: TRYBUILD=overwrite cargo llvm-cov test --no-report --tests --all-features
+      run: |
+        TRYBUILD=overwrite cargo hack llvm-cov test \
+          --feature-powerset \
+          --skip default,boxed,anyhow,eyre,unix_color,tracing \
+          --locked --no-report --tests
 
     - name: Doc Tests
-      run: TRYBUILD=overwrite cargo llvm-cov test --no-report --doc --all-features
+      run: |
+        TRYBUILD=overwrite cargo hack llvm-cov test \
+          --feature-powerset \
+          --skip default,boxed,anyhow,eyre,unix_color,tracing \
+          --locked --no-report --doc
 
     - name: Coverage Shield
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "bare_err_tree"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bare_err_tree_proc",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "bare_err_tree_proc"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bare_err_tree",
  "proc-macro2",

--- a/bare_err_tree/Cargo.toml
+++ b/bare_err_tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bare_err_tree"
-version = "0.6.2"
+version = "0.7.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -25,7 +25,7 @@ json = []
 adapt = []
 
 [dependencies]
-bare_err_tree_proc = { version = "0.4", path = "../bare_err_tree_proc", optional = true }
+bare_err_tree_proc = { version = "0.5", path = "../bare_err_tree_proc", optional = true }
 tracing-error = { version = "0.2", optional = true, default-features = false }
 tracing-core = { version = "0.1", optional = true, default-features = false }
 anyhow = { version = "1", optional = true, default-features = false }

--- a/bare_err_tree/src/fmt_logic.rs
+++ b/bare_err_tree/src/fmt_logic.rs
@@ -10,7 +10,7 @@ use core::{
     str::{self, Chars},
 };
 
-use crate::{AsErrTree, ErrTree};
+use crate::ErrTree;
 
 pub(crate) struct ErrTreeFmtWrap<const FRONT_MAX: usize, T>(RefCell<T>);
 

--- a/bare_err_tree/test_cases/std/fail_src/false_tree.stderr
+++ b/bare_err_tree/test_cases/std/fail_src/false_tree.stderr
@@ -1,12 +1,13 @@
 error[E0277]: the trait bound `std::io::Error: AsErrTree` is not satisfied
   --> test_cases/std/fail_src/false_tree.rs:20:5
    |
-20 |     #[tree_err]
-   |     ^ the trait `AsErrTree` is not implemented for `std::io::Error`, which is required by `ErrTreeConv<'_>: From<&std::io::Error>`
+20 | /     #[tree_err]
+21 | |     err: std::io::Error,
+   | |_______^ the trait `AsErrTree` is not implemented for `std::io::Error`
    |
    = help: the following other types implement trait `AsErrTree`:
              &T
              (dyn std::error::Error + 'static)
              ErrStruct
-             ErrTreeConv<'_>
-   = note: required for `ErrTreeConv<'_>` to implement `From<&std::io::Error>`
+             WrapErr<E>
+   = note: required for the cast from `&std::io::Error` to `&dyn AsErrTree`

--- a/bare_err_tree/test_cases/std/fail_src/false_tree_iter.stderr
+++ b/bare_err_tree/test_cases/std/fail_src/false_tree_iter.stderr
@@ -2,11 +2,11 @@ error[E0277]: the trait bound `std::io::Error: AsErrTree` is not satisfied
   --> test_cases/std/fail_src/false_tree_iter.rs:20:5
    |
 20 |     #[tree_iter_err]
-   |     ^ the trait `AsErrTree` is not implemented for `std::io::Error`, which is required by `ErrTreeConv<'_>: From<&std::io::Error>`
+   |     ^ the trait `AsErrTree` is not implemented for `std::io::Error`
    |
    = help: the following other types implement trait `AsErrTree`:
              &T
              (dyn std::error::Error + 'static)
              ErrStruct<'a>
-             ErrTreeConv<'_>
-   = note: required for `ErrTreeConv<'_>` to implement `From<&std::io::Error>`
+             WrapErr<E>
+   = note: required for the cast from `&std::io::Error` to `&dyn AsErrTree`

--- a/bare_err_tree/test_cases/std/fail_src/single.stderr
+++ b/bare_err_tree/test_cases/std/fail_src/single.stderr
@@ -1,8 +1,17 @@
 error[E0277]: the trait bound `[std::io::Error; 1]: std::error::Error` is not satisfied
   --> test_cases/std/fail_src/single.rs:20:5
    |
-20 | /     #[dyn_err]
+20 |       #[dyn_err]
+   |       ^ required by a bound introduced by this call
+   |  _____|
+   | |
 21 | |     err: [std::io::Error; 1],
    | |_______^ the trait `std::error::Error` is not implemented for `[std::io::Error; 1]`
    |
-   = note: required for the cast from `&[std::io::Error; 1]` to `&dyn std::error::Error`
+note: required by a bound in `WrapErr::<E>::tree`
+  --> src/flex.rs
+   |
+   | impl<E: Error> WrapErr<E> {
+   |         ^^^^^ required by this bound in `WrapErr::<E>::tree`
+   |     pub fn tree(err: &E) -> &dyn AsErrTree {
+   |            ---- required by a bound in this associated function

--- a/bare_err_tree/tests/derive_compile_fails.rs
+++ b/bare_err_tree/tests/derive_compile_fails.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "derive")]
+#![cfg(all(feature = "derive", not(miri)))]
 
 use trybuild::TestCases;
 

--- a/bare_err_tree/tests/json.rs
+++ b/bare_err_tree/tests/json.rs
@@ -56,21 +56,12 @@ mod example {
 
         assert_eq!(gen_print(), expected_json);
 
-        for (expect, real) in reconstruct(&gen_print())
-            .lines()
-            .zip(expected_lines.lines())
-        {
-            assert_eq!(expect, real);
-            println!("{real}");
-        }
-
         assert_eq!(reconstruct(&gen_print()), expected_lines);
     }
 }
 
 mod json_escapes {
     use core::error::Error;
-    use std::println;
 
     use bare_err_tree::{reconstruct_output, tree_to_json};
     use thiserror::Error;

--- a/bare_err_tree/tests/std.rs
+++ b/bare_err_tree/tests/std.rs
@@ -5,8 +5,6 @@
     not(feature = "unix_color")
 ))]
 
-use std::println;
-
 mod example {
     include!("../test_cases/std/src/bin/example.rs");
 

--- a/bare_err_tree_proc/Cargo.toml
+++ b/bare_err_tree_proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bare_err_tree_proc"
-version = "0.4.1"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
Adds `WrapErr`, which uses one well-known line of unsafe code, to replace `ErrTreeConv` with the original `&dyn AsErrTree`. This should be a pure performance and API add. Miri was added to tests for reassurance on unsafe code and coverage calculation was improved. Resolves #19.