### PR TITLE
Format Linebreaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "bare_err_tree"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bare_err_tree_proc",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "bare_err_tree_proc"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bare_err_tree",
  "proc-macro2",

--- a/bare_err_tree/Cargo.toml
+++ b/bare_err_tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bare_err_tree"
-version = "0.7.0"
+version = "0.7.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/bare_err_tree/src/json.rs
+++ b/bare_err_tree/src/json.rs
@@ -249,7 +249,7 @@ impl<'f> JsonReconstruct<'f> {
 }
 
 impl<'f> ErrTreeFormattable for JsonReconstruct<'f> {
-    fn apply_msg<W: fmt::Write + ?Sized>(&self, f: &mut W) -> fmt::Result {
+    fn apply_msg<W: fmt::Write>(&self, f: W) -> fmt::Result {
         apply_json_str(self.msg, f)
     }
 
@@ -287,7 +287,7 @@ impl<'f> ErrTreeFormattable for JsonReconstruct<'f> {
         !self.source_line.is_empty()
     }
     #[cfg(feature = "source_line")]
-    fn apply_source_line<W: fmt::Write + ?Sized>(&self, f: &mut W) -> fmt::Result {
+    fn apply_source_line<W: fmt::Write>(&self, f: W) -> fmt::Result {
         apply_json_str(self.source_line, f)
     }
 
@@ -573,7 +573,7 @@ impl Iterator for JsonStrChars<'_> {
 
 impl FusedIterator for JsonStrChars<'_> {}
 
-fn apply_json_str<F: fmt::Write + ?Sized>(s: &str, formatter: &mut F) -> fmt::Result {
+fn apply_json_str<F: fmt::Write>(s: &str, mut formatter: F) -> fmt::Result {
     for c in JsonStrChars::new(s) {
         formatter.write_char(c)?;
     }

--- a/bare_err_tree/test_cases/std/Cargo.lock
+++ b/bare_err_tree/test_cases/std/Cargo.lock
@@ -4,14 +4,14 @@ version = 4
 
 [[package]]
 name = "bare_err_tree"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bare_err_tree_proc",
 ]
 
 [[package]]
 name = "bare_err_tree_proc"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bare_err_tree/test_cases/std/Cargo.toml
+++ b/bare_err_tree/test_cases/std/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 bare_err_tree = { path = "../../", features = ["derive", "source_line"] }
 thiserror = "2"
 
+[workspace]
+
 [[bin]]
 name = "derive_testing"
 
@@ -18,3 +20,6 @@ name = "empty"
 
 [[bin]]
 name = "near-empty"
+
+[[bin]]
+name = "alt-example"

--- a/bare_err_tree/test_cases/std/src/bin/alt-example.rs
+++ b/bare_err_tree/test_cases/std/src/bin/alt-example.rs
@@ -1,0 +1,113 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::fmt::{self, Display, Formatter};
+
+use bare_err_tree::{err_tree, print_tree};
+use thiserror::Error;
+
+#[allow(dead_code)]
+fn main() {
+    let formatted = gen_print();
+    println!("{formatted}")
+}
+
+fn gen_print() -> String {
+    let fatal: MissedClassTree = MissedClass::Overslept(Overslept::new(BedTime::new(
+        2,
+        vec![
+            BedTimeReasons::ExamStressed,
+            BedTimeReasons::PlayingGames,
+            ClassProject::new("proving 1 == 2".to_string()).into(),
+        ],
+    )))
+    .into();
+    let mut formatted = String::new();
+    print_tree::<60, _, _>(fatal, &mut formatted).unwrap();
+    formatted
+}
+
+#[derive(Debug, Error)]
+#[error("{desc}")]
+struct ClassProject {
+    desc: String,
+}
+
+impl ClassProject {
+    pub fn new(desc: String) -> Self {
+        Self { desc }
+    }
+}
+
+#[derive(Debug, Error)]
+enum BedTimeReasons {
+    #[error("finishing a project")]
+    FinishingProject(#[from] ClassProject),
+    #[error("stressed about exams")]
+    ExamStressed,
+    #[error("playing video games")]
+    PlayingGames,
+}
+
+#[err_tree]
+#[derive(Debug, Default, Error)]
+struct BedTime {
+    hour: u8,
+    #[dyn_iter_err]
+    reasons: Vec<BedTimeReasons>,
+}
+
+impl BedTime {
+    #[track_caller]
+    pub fn new(hour: u8, reasons: Vec<BedTimeReasons>) -> Self {
+        Self::_tree(hour, reasons)
+    }
+}
+
+impl Display for BedTime {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let half = if self.hour < 12 { "A.M." } else { "P.M." };
+        let hour = if self.hour > 12 {
+            self.hour - 12
+        } else {
+            self.hour
+        };
+        write!(f, "went to sleep at {hour} {half}")
+    }
+}
+
+#[err_tree]
+#[derive(Debug, Error)]
+#[error("bed is comfortable")]
+struct BedComfy;
+
+#[err_tree]
+#[derive(Debug, Error, Default)]
+#[error("stayed in bed too long")]
+struct Overslept {
+    #[tree_err]
+    #[source]
+    bed_time: BedTime,
+    #[tree_err]
+    comfy: BedComfy,
+}
+
+impl Overslept {
+    #[track_caller]
+    fn new(bed_time: BedTime) -> Self {
+        Overslept::_tree(bed_time, BedComfy::_tree())
+    }
+}
+
+#[err_tree(MissedClassTree)]
+#[derive(Debug, Error)]
+#[error("missed class")]
+enum MissedClass {
+    #[tree_err]
+    Overslept(#[source] Overslept),
+    #[expect(unused)]
+    NuclearWar,
+}

--- a/bare_err_tree/tests/json.rs
+++ b/bare_err_tree/tests/json.rs
@@ -79,7 +79,7 @@ bar"
         tree_to_json::<&dyn Error, _, _>((&WeirdError) as &dyn Error, &mut out).unwrap();
 
         let expected_json = r#"{"msg":"foo\n \\ \\n \t/\nbar"}"#;
-        let expected_reconstruct = "foo\n \\ \\n \t/\nbar";
+        let expected_reconstruct = "foo\n│  \\ \\n \t/\n│ bar";
 
         assert_eq!(out, expected_json);
 

--- a/bare_err_tree_proc/Cargo.toml
+++ b/bare_err_tree_proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bare_err_tree_proc"
-version = "0.5.0"
+version = "0.5.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/bare_err_tree_proc/src/boiler.rs
+++ b/bare_err_tree_proc/src/boiler.rs
@@ -25,28 +25,28 @@ pub fn wrapper_boilerplate(
     // Core set
     let universal: TokenStream = quote! {
         #[automatically_derived]
-        impl #impl_generics core::error::Error for #name_attribute #ty_generics #where_clause {
-            fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-                core::error::Error::source(&self.inner)
+        impl #impl_generics ::core::error::Error for #name_attribute #ty_generics #where_clause {
+            fn source(&self) -> Option<&(dyn ::core::error::Error + 'static)> {
+                ::core::error::Error::source(&self.inner)
             }
         }
 
         #[automatically_derived]
-        impl #impl_generics core::fmt::Debug for #name_attribute #ty_generics #where_clause {
-            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
-                core::fmt::Debug::fmt(&self.inner, f)
+        impl #impl_generics ::core::fmt::Debug for #name_attribute #ty_generics #where_clause {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), ::core::fmt::Error> {
+                ::core::fmt::Debug::fmt(&self.inner, f)
             }
         }
 
         #[automatically_derived]
-        impl #impl_generics core::fmt::Display for #name_attribute #ty_generics #where_clause {
-            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
-                core::fmt::Display::fmt(&self.inner, f)
+        impl #impl_generics ::core::fmt::Display for #name_attribute #ty_generics #where_clause {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> Result<(), ::core::fmt::Error> {
+                ::core::fmt::Display::fmt(&self.inner, f)
             }
         }
 
         #[automatically_derived]
-        impl #impl_generics core::convert::From<#ident #ty_generics> for #name_attribute #ty_generics #where_clause {
+        impl #impl_generics ::core::convert::From<#ident #ty_generics> for #name_attribute #ty_generics #where_clause {
             #[track_caller]
             fn from(inner: #ident #ty_generics) -> Self {
                 Self::_tree(inner)
@@ -54,14 +54,14 @@ pub fn wrapper_boilerplate(
         }
 
         #[automatically_derived]
-        impl #impl_generics core::convert::From<#name_attribute #ty_generics> for #ident #ty_generics #where_clause {
+        impl #impl_generics ::core::convert::From<#name_attribute #ty_generics> for #ident #ty_generics #where_clause {
             fn from(value: #name_attribute #ty_generics) -> Self {
                 value.inner
             }
         }
 
         #[automatically_derived]
-        impl #impl_generics core::ops::Deref for #name_attribute #ty_generics #where_clause {
+        impl #impl_generics ::core::ops::Deref for #name_attribute #ty_generics #where_clause {
             type Target = #ident #ty_generics;
             fn deref(&self) -> &Self::Target {
                 &self.inner
@@ -69,7 +69,7 @@ pub fn wrapper_boilerplate(
         }
 
         #[automatically_derived]
-        impl #impl_generics core::ops::DerefMut for #name_attribute #ty_generics #where_clause {
+        impl #impl_generics ::core::ops::DerefMut for #name_attribute #ty_generics #where_clause {
             fn deref_mut(&mut self) -> &mut Self::Target {
                 &mut self.inner
             }
@@ -99,12 +99,12 @@ pub fn wrapper_boilerplate(
             .map(|extra| match extra.to_string().to_lowercase().as_str() {
                 "eq" => quote! {
                     #[automatically_derived]
-                    impl #impl_generics core::cmp::Eq for #name_attribute #ty_generics #where_clause {}
+                    impl #impl_generics ::core::cmp::Eq for #name_attribute #ty_generics #where_clause {}
                 }
                 .into(),
                 "partialeq" => quote! {
                     #[automatically_derived]
-                    impl #impl_generics core::cmp::PartialEq<#name_attribute #ty_generics> for #name_attribute #ty_generics #where_clause {
+                    impl #impl_generics ::core::cmp::PartialEq<#name_attribute #ty_generics> for #name_attribute #ty_generics #where_clause {
                         fn eq(&self, other: &#name_attribute #ty_generics) -> bool {
                             self.inner == other.inner
                         }
@@ -113,25 +113,25 @@ pub fn wrapper_boilerplate(
                 .into(),
                 "ord" => quote! {
                     #[automatically_derived]
-                    impl #impl_generics core::cmp::Ord for #name_attribute #ty_generics #where_clause {
+                    impl #impl_generics ::core::cmp::Ord for #name_attribute #ty_generics #where_clause {
                         fn ord(&self, other: &Self) -> bool {
-                            <#ident #ty_generics #where_clause as core::cmp::Ord>::ord(self.inner, other.inner)
+                            <#ident #ty_generics #where_clause as ::core::cmp::Ord>::ord(self.inner, other.inner)
                         }
                     }
                 }
                 .into(),
                 "partialord" => quote! {
                     #[automatically_derived]
-                    impl #impl_generics core::cmp::PartialOrd for #name_attribute #ty_generics #where_clause {
-                        fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-                            <#ident #ty_generics #where_clause as core::cmp::ParitalOrd>::partial_cmp(self.inner, other.inner)
+                    impl #impl_generics ::core::cmp::PartialOrd for #name_attribute #ty_generics #where_clause {
+                        fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
+                            <#ident #ty_generics #where_clause as ::core::cmp::ParitalOrd>::partial_cmp(self.inner, other.inner)
                         }
                     }
                 }
                 .into(),
                 "clone" => quote! {
                     #[automatically_derived]
-                    impl #impl_generics core::clone::Clone for #name_attribute #ty_generics #where_clause {
+                    impl #impl_generics ::core::clone::Clone for #name_attribute #ty_generics #where_clause {
                         fn clone(&self) -> Self {
                             Self {
                                 inner: self.inner.clone(),
@@ -143,9 +143,9 @@ pub fn wrapper_boilerplate(
                 .into(),
                 "hash" => quote! {
                     #[automatically_derived]
-                    impl #impl_generics core::hash::Hash for #name_attribute #ty_generics #where_clause {
+                    impl #impl_generics ::core::hash::Hash for #name_attribute #ty_generics #where_clause {
                         fn hash<H>(&self, state: &mut H)
-                            where H: core::hash::Hasher
+                            where H: ::core::hash::Hasher
                         {
                             self.inner.hash(state)
                         }
@@ -154,12 +154,12 @@ pub fn wrapper_boilerplate(
                 .into(),
                 "default" => quote! {
                     #[automatically_derived]
-                    impl #impl_generics core::default::Default for #name_attribute #ty_generics #where_clause {
+                    impl #impl_generics ::core::default::Default for #name_attribute #ty_generics #where_clause {
                         #[track_caller]
                         fn default() -> Self {
                             Self {
                                 inner: #ident ::default(),
-                                _err_tree_pkg: bare_err_tree::ErrTreePkg::default(),
+                                _err_tree_pkg: ::bare_err_tree::ErrTreePkg::default(),
                             }
                         }
                     }

--- a/bare_err_tree_proc/src/errtype.rs
+++ b/bare_err_tree_proc/src/errtype.rs
@@ -43,14 +43,14 @@ pub fn gen_sources_struct(errs: &[TreeErr], foreign: bool) -> proc_macro2::Token
 
     let conv = |x, span| {
         quote_spanned! {
-            span=> let #x = & self.#x as &dyn bare_err_tree::AsErrTree;
+            span=> let #x = & self.#x as &dyn ::bare_err_tree::AsErrTree;
                 let #x = core::iter::once(#x);
         }
     };
 
     let conv_dyn = |x, span| {
         quote_spanned! {
-            span=> let #x = bare_err_tree::WrapErr::tree(& self.#x);
+            span=> let #x = ::bare_err_tree::WrapErr::tree(& self.#x);
                 let #x = core::iter::once(#x);
         }
     };
@@ -58,13 +58,13 @@ pub fn gen_sources_struct(errs: &[TreeErr], foreign: bool) -> proc_macro2::Token
     let conv_dyn_iter = |x, span| {
         quote_spanned! {
             span=> let #x = #parent.#x.iter()
-                .map(bare_err_tree::WrapErr::tree);
+                .map(::bare_err_tree::WrapErr::tree);
         }
     };
 
     let conv_iter = |x, span| {
         quote_spanned! {
-            span=> let #x = #parent.#x.iter().map(|x| x as &dyn bare_err_tree::AsErrTree);
+            span=> let #x = #parent.#x.iter().map(|x| x as &dyn ::bare_err_tree::AsErrTree);
         }
     };
 
@@ -80,7 +80,7 @@ pub fn gen_sources_struct(errs: &[TreeErr], foreign: bool) -> proc_macro2::Token
         #(#gen_vars)*
         let mut sources = &mut core::iter::empty()#(.chain(#ids))*;
 
-        (func)(bare_err_tree::ErrTree::with_pkg(self, sources, _err_tree_pkg))
+        (func)(::bare_err_tree::ErrTree::with_pkg(self, sources, _err_tree_pkg))
     }
 }
 
@@ -89,9 +89,9 @@ pub fn gen_sources_enum(errs: &[TreeErr], ident: &Ident) -> proc_macro2::TokenSt
     let conv = |x, span| {
         quote_spanned! {
             span=> #ident :: #x (x) => {
-                let x = x as &dyn bare_err_tree::AsErrTree;
+                let x = x as &dyn ::bare_err_tree::AsErrTree;
                 let x = &mut core::iter::once(x);
-                (func)(bare_err_tree::ErrTree::with_pkg(self, x, _err_tree_pkg))
+                (func)(::bare_err_tree::ErrTree::with_pkg(self, x, _err_tree_pkg))
             },
         }
     };
@@ -99,9 +99,9 @@ pub fn gen_sources_enum(errs: &[TreeErr], ident: &Ident) -> proc_macro2::TokenSt
     let conv_dyn = |x, span| {
         quote_spanned! {
             span=> #ident :: #x (x) => {
-                let x = bare_err_tree::WrapErr::tree(x);
+                let x = ::bare_err_tree::WrapErr::tree(x);
                 let x = &mut core::iter::once(x);
-                (func)(bare_err_tree::ErrTree::with_pkg(self, x, _err_tree_pkg))
+                (func)(::bare_err_tree::ErrTree::with_pkg(self, x, _err_tree_pkg))
             },
         }
     };
@@ -110,7 +110,7 @@ pub fn gen_sources_enum(errs: &[TreeErr], ident: &Ident) -> proc_macro2::TokenSt
         quote_spanned! {
             span=> #ident :: #x (x) => {
                 let x = &mut x.iter().map(|z| z as &dyn AsErrTree);
-                (func)(bare_err_tree::ErrTree::with_pkg(self, x, _err_tree_pkg))
+                (func)(::bare_err_tree::ErrTree::with_pkg(self, x, _err_tree_pkg))
             }
         }
     };
@@ -118,8 +118,8 @@ pub fn gen_sources_enum(errs: &[TreeErr], ident: &Ident) -> proc_macro2::TokenSt
     let conv_iter_dyn = |x, span| {
         quote_spanned! {
             span=> #ident :: #x (x) => {
-                let x = &mut x.iter().map(bare_err_tree::WrapErr::tree);
-                (func)(bare_err_tree::ErrTree::with_pkg(self, x, _err_tree_pkg))
+                let x = &mut x.iter().map(::bare_err_tree::WrapErr::tree);
+                (func)(::bare_err_tree::ErrTree::with_pkg(self, x, _err_tree_pkg))
             }
         }
     };
@@ -135,7 +135,7 @@ pub fn gen_sources_enum(errs: &[TreeErr], ident: &Ident) -> proc_macro2::TokenSt
         let sources = match &self.inner {
             #(#gen_arms)*
             _ => {
-                (func)(bare_err_tree::ErrTree::with_pkg(self, &mut core::iter::empty(), _err_tree_pkg))
+                (func)(::bare_err_tree::ErrTree::with_pkg(self, &mut core::iter::empty(), _err_tree_pkg))
             }
         };
     }

--- a/bare_err_tree_proc/src/lib.rs
+++ b/bare_err_tree_proc/src/lib.rs
@@ -460,16 +460,16 @@ fn err_tree_struct(
             let field_ident = proc_macro2::Ident::new("_err_tree_pkg", Span::call_site().into());
             fields.named.push(
                 Field::parse_named
-                    .parse2(quote! { #field_ident: bare_err_tree::ErrTreePkg })
+                    .parse2(quote! { #field_ident: ::bare_err_tree::ErrTreePkg })
                     .unwrap(),
             );
             let field_ident = field_ident.into_token_stream();
 
             quote! {
                 #[automatically_derived]
-                impl #impl_generics bare_err_tree::AsErrTree for #ident #ty_generics #where_clause {
+                impl #impl_generics ::bare_err_tree::AsErrTree for #ident #ty_generics #where_clause {
                     #[track_caller]
-                    fn as_err_tree(&self, func: &mut dyn FnMut(bare_err_tree::ErrTree<'_>)) {
+                    fn as_err_tree(&self, func: &mut dyn FnMut(::bare_err_tree::ErrTree<'_>)) {
                         let _err_tree_pkg = &self.#field_ident;
                         #sources
                     }
@@ -480,7 +480,7 @@ fn err_tree_struct(
                     #[track_caller]
                     #[allow(clippy::too_many_arguments)]
                     fn _tree(#field_bounds) -> Self {
-                        let #field_ident = bare_err_tree::ErrTreePkg::new();
+                        let #field_ident = ::bare_err_tree::ErrTreePkg::new();
                         Self {
                             #(#field_names,)*
                             #field_ident
@@ -496,15 +496,15 @@ fn err_tree_struct(
             let prev_len = syn::Index::from(fields.unnamed.len());
             fields.unnamed.push(
                 Field::parse_unnamed
-                    .parse2(quote! { bare_err_tree::ErrTreePkg })
+                    .parse2(quote! { ::bare_err_tree::ErrTreePkg })
                     .unwrap(),
             );
 
             quote! {
                 #[automatically_derived]
-                impl #impl_generics bare_err_tree::AsErrTree for #ident #ty_generics #where_clause {
+                impl #impl_generics ::bare_err_tree::AsErrTree for #ident #ty_generics #where_clause {
                     #[track_caller]
-                    fn as_err_tree(&self, func: &mut dyn FnMut(bare_err_tree::ErrTree<'_>)) {
+                    fn as_err_tree(&self, func: &mut dyn FnMut(::bare_err_tree::ErrTree<'_>)) {
                         let _err_tree_pkg = &self.#prev_len;
                         #sources
                     }
@@ -515,7 +515,7 @@ fn err_tree_struct(
                     #[track_caller]
                     #[allow(clippy::too_many_arguments)]
                     fn _tree(#field_bounds) -> Self {
-                        let _err_tree_pkg = bare_err_tree::ErrTreePkg::new();
+                        let _err_tree_pkg = ::bare_err_tree::ErrTreePkg::new();
                         Self (
                             #(#field_names,)*
                             _err_tree_pkg
@@ -533,7 +533,7 @@ fn err_tree_struct(
             let mut named = Punctuated::default();
             named.push(
                 Field::parse_named
-                    .parse2(quote! { #field_ident: bare_err_tree::ErrTreePkg })
+                    .parse2(quote! { #field_ident: ::bare_err_tree::ErrTreePkg })
                     .unwrap(),
             );
             let field_ident = field_ident.into_token_stream();
@@ -544,9 +544,9 @@ fn err_tree_struct(
 
             quote! {
                 #[automatically_derived]
-                impl #impl_generics bare_err_tree::AsErrTree for #ident #ty_generics #where_clause {
+                impl #impl_generics ::bare_err_tree::AsErrTree for #ident #ty_generics #where_clause {
                     #[track_caller]
-                    fn as_err_tree(&self, func: &mut dyn FnMut(bare_err_tree::ErrTree<'_>)) {
+                    fn as_err_tree(&self, func: &mut dyn FnMut(::bare_err_tree::ErrTree<'_>)) {
                         let _err_tree_pkg = &self.#field_ident;
                         #sources
                     }
@@ -556,7 +556,7 @@ fn err_tree_struct(
                 impl #impl_generics #ident #ty_generics #where_clause {
                     #[track_caller]
                     fn _tree() -> Self {
-                        let #field_ident = bare_err_tree::ErrTreePkg::new();
+                        let #field_ident = ::bare_err_tree::ErrTreePkg::new();
                         Self {
                             #field_ident
                         }
@@ -564,7 +564,7 @@ fn err_tree_struct(
                 }
 
                 #[automatically_derived]
-                impl #impl_generics core::default::Default for #ident #ty_generics #where_clause {
+                impl #impl_generics ::core::default::Default for #ident #ty_generics #where_clause {
                     #[track_caller]
                     fn default() -> Self {
                         Self::_tree()


### PR DESCRIPTION
Adds front formatting for linebreaks in error messages. Also uses absolute paths for the macro, to avoid any potential renaming bugs.