### PR TITLE
Offer ErrTreeDisplay

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
       all-dependencies:
         patterns:
           - '*'
+        update-types:
+          - "major"
+          - "minor"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "bare_err_tree"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bare_err_tree_proc",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Support for the extra information prints does not change the type or public API (besides a hidden field or deref).
 It is added via macro or manual implementation of the `AsErrTree` trait (see
 the [docs][Docs] for details).
-End users can then use `tree_unwrap` or `print_tree` to get better error output,
+End users can then use `ErrTreeDisplay` or `tree_unwrap` to get better error output,
 or store as [JSON][JSON] for later reconstruction.
 
 Unlike [anyhow][Anyhow], [eyre][Eyre], or [error-stack][ErrorStack], the extra

--- a/bare_err_tree/Cargo.toml
+++ b/bare_err_tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bare_err_tree"
-version = "0.7.1"
+version = "0.8.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/bare_err_tree/Cargo.toml
+++ b/bare_err_tree/Cargo.toml
@@ -25,7 +25,6 @@ anyhow = ["dep:anyhow"]
 eyre = ["dep:eyre"]
 unix_color = []
 json = []
-adapt = []
 
 [dependencies]
 bare_err_tree_proc = { version = "0.5", path = "../bare_err_tree_proc", optional = true }

--- a/bare_err_tree/src/fmt_logic.rs
+++ b/bare_err_tree/src/fmt_logic.rs
@@ -5,27 +5,30 @@
  */
 
 use core::{
-    cell::RefCell,
     fmt::{self, Display, Formatter, Write},
     str::{self, Chars},
 };
 
-use crate::ErrTree;
+use crate::{AsErrTree, ErrTree};
 
-pub(crate) struct ErrTreeFmtWrap<const FRONT_MAX: usize, T>(RefCell<T>);
+pub struct ErrTreeDisplay<const FRONT_MAX: usize, E>(E);
 
-impl<const FRONT_MAX: usize, T> ErrTreeFmtWrap<FRONT_MAX, T> {
-    pub fn new(tree: T) -> Self {
-        Self(RefCell::new(tree))
+impl<const FRONT_MAX: usize, E> ErrTreeDisplay<FRONT_MAX, E> {
+    pub fn new(tree: E) -> Self {
+        Self(tree)
     }
 }
 
-impl<const FRONT_MAX: usize, T> Display for ErrTreeFmtWrap<FRONT_MAX, T>
+impl<const FRONT_MAX: usize, E> Display for ErrTreeDisplay<FRONT_MAX, E>
 where
-    T: ErrTreeFormattable,
+    E: AsErrTree,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        fmt_tree::<FRONT_MAX, _, _>(&mut *self.0.borrow_mut(), f)
+        let mut res = Ok(());
+        self.0.as_err_tree(&mut |tree| {
+            res = fmt_tree::<FRONT_MAX, _, _>(tree, f);
+        });
+        res
     }
 }
 

--- a/bare_err_tree/src/fmt_logic.rs
+++ b/bare_err_tree/src/fmt_logic.rs
@@ -9,20 +9,15 @@ use core::{
     str::{self, Chars},
 };
 
-use crate::{AsErrTree, ErrTree};
+use crate::{AsErrTree, ErrTree, ErrTreeDisplay};
 
-pub struct ErrTreeDisplay<const FRONT_MAX: usize, E>(E);
-
-impl<const FRONT_MAX: usize, E> ErrTreeDisplay<FRONT_MAX, E> {
+impl<E: AsErrTree, const FRONT_MAX: usize> ErrTreeDisplay<E, FRONT_MAX> {
     pub fn new(tree: E) -> Self {
         Self(tree)
     }
 }
 
-impl<const FRONT_MAX: usize, E> Display for ErrTreeDisplay<FRONT_MAX, E>
-where
-    E: AsErrTree,
-{
+impl<E: AsErrTree, const FRONT_MAX: usize> Display for ErrTreeDisplay<E, FRONT_MAX> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut res = Ok(());
         self.0.as_err_tree(&mut |tree| {

--- a/bare_err_tree/src/json.rs
+++ b/bare_err_tree/src/json.rs
@@ -13,7 +13,10 @@ use core::{
     str::Chars,
 };
 
-use crate::{fmt_tree, AsErrTree, ErrTree, ErrTreeFormattable};
+use crate::{
+    fmt_logic::{fmt_tree, ErrTreeFormattable},
+    AsErrTree, ErrTree,
+};
 
 /// Produces JSON to store [`ErrTree`] formatted output.
 ///
@@ -302,9 +305,11 @@ impl<'f> ErrTreeFormattable for JsonReconstruct<'f> {
     #[cfg(feature = "tracing")]
     fn apply_trace<F>(&self, mut func: F) -> fmt::Result
     where
-        F: FnMut(crate::TraceSpan<Self::TraceSpanId, Self::TraceSpanIter<'_>>) -> fmt::Result,
+        F: FnMut(
+            crate::fmt_logic::TraceSpan<Self::TraceSpanId, Self::TraceSpanIter<'_>>,
+        ) -> fmt::Result,
     {
-        use crate::TraceSpan;
+        use crate::fmt_logic::TraceSpan;
 
         const TARGET: &str = "\"target\"";
         const NAME: &str = "\"name\"";

--- a/bare_err_tree/src/lib.rs
+++ b/bare_err_tree/src/lib.rs
@@ -81,18 +81,14 @@ extern crate alloc;
 #[cfg(feature = "source_line")]
 use core::panic::Location;
 
-use core::{
-    error::Error,
-    fmt::{self},
-};
+use core::error::Error;
 
 mod pkg;
 pub use pkg::*;
 pub mod flex;
 pub use flex::*;
-mod fmt_logic;
-use fmt_logic::*;
 mod buffer;
+mod fmt_logic;
 use buffer::*;
 
 #[cfg(feature = "json")]

--- a/bare_err_tree/src/lib.rs
+++ b/bare_err_tree/src/lib.rs
@@ -10,8 +10,8 @@
 Support for the extra information prints does not change the type or public
 API (besides a hidden field or deref). It is added via macro or manual
 implementation of the [`AsErrTree`] trait. End users can then use
-[`tree_unwrap`] or [`print_tree`] to get better error output, or store as JSON
-for later reconstruction.
+[`ErrTreeDisplay`] or [`tree_unwrap`] to get better error output, or store as
+JSON for later reconstruction.
 
 If none of the [tracking feature flags](#tracking-feature-flags) are enabled,
 the metadata is set to the [`unit`] type to take zero space.
@@ -29,7 +29,6 @@ Usage of the [`err_tree`] macro incurs a compliation time cost.
 * `unix_color`: Outputs UNIX console codes for emphasis.
 * `anyhow`: Adds implementation for [`anyhow::Error`].
 * `eyre`: Adds implementation for [`eyre::Report`].
-* `adapt`: Provides a [`std::io::Write`] adapter.
 #### Tracking Feature Flags
 * `source_line`: Tracks the source line of tree errors.
 * `tracing`: Produces a `tracing` backtrace with [`tracing_error`].
@@ -42,7 +41,7 @@ implementation.
 #### Feature Flags in Libraries
 Libraries should NOT enable any of the
 [tracking feature flags](#tracking-feature-flags) by default. Those are tunable
-for a particular binary's environment and needs. [`tree_unwrap`]/[`print_tree`]
+for a particular binary's environment and needs. [`ErrTreeDisplay`]/[`tree_unwrap`]
 should be used sparingly within the library, ideally with a small `FRONT_MAX`
 to minimize out of stack memory errors.
 
@@ -50,9 +49,9 @@ to minimize out of stack memory errors.
 Specify desired tracking features by importing `bare_err_tree` in `Cargo.toml`.
 (e.g. `bare_err_tree = { version = "*", features = ["source_line"] }`)
 
-Call [`tree_unwrap`] on the [`Result`] or [`print_tree`] on the [`Error`] with
-`FRONT_MAX` set to `6 * (maximum tree depth)`. Note that unless `heap_buffer`
-is enabled, `FRONT_MAX` (x3 if `tracing` is enabled) bytes will be
+Call [`tree_unwrap`] on the [`Result`] or [`ErrTreeDisplay`] on the [`Error`]
+with `FRONT_MAX` set to `6 * (maximum tree depth)`. Note that unless
+`heap_buffer` is enabled, `FRONT_MAX` (x3 if `tracing` is enabled) bytes will be
 occupied on stack for the duration of a print call. Make sure this falls
 within platform stack size, and single stack frame size, limits.
 
@@ -75,9 +74,6 @@ Contributions are welcome at
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(coverage, feature(coverage_attribute))]
-
-#[cfg(feature = "adapt")]
-extern crate std;
 
 #[cfg(any(feature = "heap_buffer", feature = "boxed"))]
 extern crate alloc;
@@ -131,7 +127,7 @@ where
             panic!(
                 "Panic origin at: {:#?}\n{}",
                 core::panic::Location::caller(),
-                ErrTreeDisplay::<FRONT_MAX, _>::new(tree)
+                ErrTreeDisplay::<_, FRONT_MAX>::new(tree)
             );
         }
     }
@@ -159,96 +155,11 @@ where
 /// #   string::String,
 /// #   io::self,
 /// # };
-/// use bare_err_tree::{AsErrTree, print_tree};
+/// use bare_err_tree::{ErrTreeDisplay};
 ///
-/// const PRINT_SIZE: usize = 60;
-///
-/// fn sized_print<E, F>(tree: E, formatter: F) -> fmt::Result
-/// where
-///     E: AsErrTree,
-///     F: fmt::Write,
-/// {
-///     print_tree::<PRINT_SIZE, _, _>(tree, formatter)
-/// }
-///
-/// let mut out = String::new();
-/// sized_print(&io::Error::last_os_error() as &dyn Error, &mut out).unwrap();
-/// println!("{out}");
+/// println!("{}", ErrTreeDisplay::<_, 60>(&io::Error::last_os_error() as &dyn Error));
 /// ```
-#[track_caller]
-pub fn print_tree<const FRONT_MAX: usize, E, F>(tree: E, mut formatter: F) -> fmt::Result
-where
-    E: AsErrTree,
-    F: fmt::Write,
-{
-    let mut res = Ok(());
-    tree.as_err_tree(&mut |tree| {
-        res = fmt_tree::<FRONT_MAX, _, _>(tree, &mut formatter);
-    });
-    res
-}
-
-#[cfg(feature = "adapt")]
-/// Converts [`std::io::Write`] to [`core::fmt::Write`].
-///
-/// Provided for using [`print_tree`] without a [`std::string::String`] buffer.
-/// This adapter does not call [`flush`][`std::io::Write::flush`], only
-/// [`write_all`][`std::io::Write::write_all`].
-///
-/// ```rust
-/// # use std::{
-/// #   panic::Location,
-/// #   error::Error,
-/// #   fmt::{self, Write, Display, Formatter},
-/// #   io::{self, stdout},
-/// # };
-/// use bare_err_tree::{AdaptWrite, AsErrTree, print_tree};
-///
-/// const PRINT_SIZE: usize = 60;
-///
-/// fn sized_print<E, F>(tree: E, formatter: F) -> fmt::Result
-/// where
-///     E: AsErrTree,
-///     F: fmt::Write,
-/// {
-///     print_tree::<PRINT_SIZE, _, _>(tree, formatter)
-/// }
-///
-/// fn io_as_tree() {
-///     let mut out = AdaptWrite(stdout());
-///     sized_print(&io::Error::last_os_error() as &dyn Error, &mut out).unwrap();
-///     out.flush().unwrap();
-/// }
-/// ```
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct AdaptWrite<W>(pub W);
-
-#[cfg(feature = "adapt")]
-impl<W> From<W> for AdaptWrite<W> {
-    fn from(value: W) -> Self {
-        Self(value)
-    }
-}
-
-#[cfg(feature = "adapt")]
-impl<W> core::fmt::Write for AdaptWrite<W>
-where
-    W: std::io::Write,
-{
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.0.write_all(s.as_bytes()).map_err(|_| fmt::Error)
-    }
-}
-
-#[cfg(feature = "adapt")]
-impl<W> AdaptWrite<W>
-where
-    W: std::io::Write,
-{
-    pub fn flush(&mut self) -> std::io::Result<()> {
-        self.0.flush()
-    }
-}
+pub struct ErrTreeDisplay<E: AsErrTree, const FRONT_MAX: usize = 60>(pub E);
 
 /// Intermediate struct for printing created by [`AsErrTree`].
 ///

--- a/bare_err_tree/src/lib.rs
+++ b/bare_err_tree/src/lib.rs
@@ -128,15 +128,11 @@ where
     match res {
         Ok(x) => x,
         Err(tree) => {
-            let loc = core::panic::Location::caller();
-            tree.as_err_tree(&mut |tree| {
-                panic!(
-                    "Panic origin at: {:#?}\n{}",
-                    loc,
-                    ErrTreeFmtWrap::<FRONT_MAX, _>::new(tree)
-                )
-            });
-            unreachable!()
+            panic!(
+                "Panic origin at: {:#?}\n{}",
+                core::panic::Location::caller(),
+                ErrTreeDisplay::<FRONT_MAX, _>::new(tree)
+            );
         }
     }
 }

--- a/bare_err_tree/test_cases/std/Cargo.lock
+++ b/bare_err_tree/test_cases/std/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "bare_err_tree"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bare_err_tree_proc",
 ]

--- a/bare_err_tree/test_cases/std/src/bin/alt-example.rs
+++ b/bare_err_tree/test_cases/std/src/bin/alt-example.rs
@@ -4,9 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Display, Formatter, Write};
 
-use bare_err_tree::{err_tree, print_tree};
+use bare_err_tree::{err_tree, ErrTreeDisplay};
 use thiserror::Error;
 
 #[allow(dead_code)]
@@ -26,7 +26,7 @@ fn gen_print() -> String {
     )))
     .into();
     let mut formatted = String::new();
-    print_tree::<60, _, _>(fatal, &mut formatted).unwrap();
+    write!(formatted, "{}", ErrTreeDisplay::<_, 60>(fatal)).unwrap();
     formatted
 }
 

--- a/bare_err_tree/test_cases/std/src/bin/empty.rs
+++ b/bare_err_tree/test_cases/std/src/bin/empty.rs
@@ -4,7 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use bare_err_tree::print_tree;
+use bare_err_tree::ErrTreeDisplay;
+use std::fmt::Write;
 use thiserror::Error;
 
 #[allow(dead_code)]
@@ -16,7 +17,12 @@ fn main() {
 fn gen_print() -> String {
     let fatal = Empty;
     let mut formatted = String::new();
-    print_tree::<60, _, _>(&fatal as &dyn std::error::Error, &mut formatted).unwrap();
+    write!(
+        formatted,
+        "{}",
+        ErrTreeDisplay::<_, 60>(&fatal as &dyn std::error::Error)
+    )
+    .unwrap();
     formatted
 }
 

--- a/bare_err_tree/test_cases/std/src/bin/example.rs
+++ b/bare_err_tree/test_cases/std/src/bin/example.rs
@@ -4,9 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Display, Formatter, Write};
 
-use bare_err_tree::{err_tree, print_tree};
+use bare_err_tree::{err_tree, ErrTreeDisplay};
 use thiserror::Error;
 
 #[allow(dead_code)]
@@ -26,7 +26,7 @@ fn gen_print() -> String {
     )))
     .into();
     let mut formatted = String::new();
-    print_tree::<60, _, _>(fatal, &mut formatted).unwrap();
+    write!(&mut formatted, "{}", ErrTreeDisplay::<_, 60>(fatal)).unwrap();
     formatted
 }
 

--- a/bare_err_tree/test_cases/std/src/bin/near-empty.rs
+++ b/bare_err_tree/test_cases/std/src/bin/near-empty.rs
@@ -4,7 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use bare_err_tree::{err_tree, print_tree};
+use bare_err_tree::{err_tree, ErrTreeDisplay};
+use std::fmt::Write;
 use thiserror::Error;
 
 #[allow(dead_code)]
@@ -16,7 +17,7 @@ fn main() {
 fn gen_print() -> String {
     let fatal = Empty::_tree();
     let mut formatted = String::new();
-    print_tree::<60, _, _>(fatal, &mut formatted).unwrap();
+    write!(formatted, "{}", ErrTreeDisplay::<_, 60>(fatal)).unwrap();
     formatted
 }
 

--- a/bare_err_tree/test_cases/trace/Cargo.lock
+++ b/bare_err_tree/test_cases/trace/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "bare_err_tree"
-version = "0.6.0"
+version = "0.8.0"
 dependencies = [
  "bare_err_tree_proc",
  "tracing-core",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "bare_err_tree_proc"
-version = "0.4.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bare_err_tree/test_cases/trace/src/bin/near-empty.rs
+++ b/bare_err_tree/test_cases/trace/src/bin/near-empty.rs
@@ -4,7 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use bare_err_tree::{err_tree, print_tree};
+use bare_err_tree::{err_tree, ErrTreeDisplay};
+use std::fmt::Write;
 use thiserror::Error;
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{field::MakeExt, layer::SubscriberExt};
@@ -33,7 +34,7 @@ fn gen_print() -> String {
 
     let fatal = Empty::_tree();
     let mut formatted = String::new();
-    print_tree::<60, _, _>(fatal, &mut formatted).unwrap();
+    write!(formatted, "{}", ErrTreeDisplay::<_, 60>(fatal)).unwrap();
     formatted
 }
 

--- a/bare_err_tree/test_cases/trace/src/bin/trace_example.rs
+++ b/bare_err_tree/test_cases/trace/src/bin/trace_example.rs
@@ -4,9 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Display, Formatter, Write};
 
-use bare_err_tree::{err_tree, print_tree};
+use bare_err_tree::{err_tree, ErrTreeDisplay};
 use thiserror::Error;
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{field::MakeExt, layer::SubscriberExt};
@@ -50,7 +50,7 @@ fn gen_print_inner() -> String {
     ))
     .into();
     let mut formatted = String::new();
-    print_tree::<60, _, _>(fatal, &mut formatted).unwrap();
+    write!(formatted, "{}", ErrTreeDisplay::<_, 60>(fatal)).unwrap();
     formatted
 }
 

--- a/bare_err_tree/test_cases/trace/src/bin/trailing.rs
+++ b/bare_err_tree/test_cases/trace/src/bin/trailing.rs
@@ -4,7 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use bare_err_tree::{err_tree, print_tree};
+use bare_err_tree::{err_tree, ErrTreeDisplay};
+use std::fmt::Write;
 use thiserror::Error;
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{field::MakeExt, layer::SubscriberExt};
@@ -36,7 +37,7 @@ fn gen_print_inner() -> String {
     )))
     .into();
     let mut formatted = String::new();
-    print_tree::<60, _, _>(fatal, &mut formatted).unwrap();
+    write!(formatted, "{}", ErrTreeDisplay::<_, 60>(fatal)).unwrap();
     formatted
 }
 

--- a/bare_err_tree/tests/shared.rs
+++ b/bare_err_tree/tests/shared.rs
@@ -18,16 +18,16 @@ mod near_empty {
     #[test]
     fn near_empty() {
         let expected_lines = "EMPTY
-╰─ at bare_err_tree/tests/../test_cases/std/src/bin/near-empty.rs:17:17";
+╰─ at bare_err_tree/tests/../test_cases/std/src/bin/near-empty.rs:18:17";
 
         assert_eq!(gen_print(), expected_lines);
     }
 }
 
 mod multiline {
-    use core::error::Error;
+    use core::{error::Error, fmt::Write};
 
-    use bare_err_tree::print_tree;
+    use bare_err_tree::ErrTreeDisplay;
     use thiserror::Error;
 
     #[derive(Debug, Error)]
@@ -49,7 +49,7 @@ mod multiline {
 
         let err = MultilineErr(InnerMultiline);
         let mut out = String::new();
-        print_tree::<60, _, _>(&err as &dyn Error, &mut out).unwrap();
+        write!(out, "{}", ErrTreeDisplay::<_, 60>(&err as &dyn Error)).unwrap();
 
         assert_eq!(out, expected_lines);
     }

--- a/bare_err_tree/tests/std.rs
+++ b/bare_err_tree/tests/std.rs
@@ -39,7 +39,7 @@ mod near_empty {
     #[test]
     fn near_empty() {
         let expected_lines = "EMPTY
-╰─ at bare_err_tree/tests/../test_cases/std/src/bin/near-empty.rs:17:17";
+╰─ at bare_err_tree/tests/../test_cases/std/src/bin/near-empty.rs:18:17";
 
         assert_eq!(gen_print(), expected_lines);
     }

--- a/bare_err_tree/tests/tracing.rs
+++ b/bare_err_tree/tests/tracing.rs
@@ -63,7 +63,7 @@ mod near_empty {
     #[test]
     fn near_empty() {
         let expected_lines = "EMPTY
-╰─ at bare_err_tree/tests/../test_cases/trace/src/bin/near-empty.rs:34:17";
+╰─ at bare_err_tree/tests/../test_cases/trace/src/bin/near-empty.rs:35:17";
 
         assert_eq!(gen_print(), expected_lines);
     }
@@ -75,18 +75,18 @@ mod trailing {
     #[test]
     fn near_empty() {
         let expected_lines = "missed class
-├─ at bare_err_tree/tests/../test_cases/trace/src/bin/trailing.rs:37:6
+├─ at bare_err_tree/tests/../test_cases/trace/src/bin/trailing.rs:38:6
 │
 ├─ tracing frame 0 => tracing::trailing::gen_print_inner
-│        at bare_err_tree/tests/../test_cases/trace/src/bin/trailing.rs:32
+│        at bare_err_tree/tests/../test_cases/trace/src/bin/trailing.rs:33
 │
 ╰─▶ stayed in bed too long
-    ├─ at bare_err_tree/tests/../test_cases/trace/src/bin/trailing.rs:34:57
+    ├─ at bare_err_tree/tests/../test_cases/trace/src/bin/trailing.rs:35:57
     │
     ├─ 1 duplicate tracing frame(s): [0]
     │
     ╰─▶ proving 1 == 2
-        ├─ at bare_err_tree/tests/../test_cases/trace/src/bin/trailing.rs:34:72
+        ├─ at bare_err_tree/tests/../test_cases/trace/src/bin/trailing.rs:35:72
         │
         ╰─ 1 duplicate tracing frame(s): [0]";
 


### PR DESCRIPTION
Implement suggestions of https://www.reddit.com/r/rust/comments/1i87ok7/comment/m8uzy31/ by producing a public `ErrTreeDisplay`, removing the I/O adapter, and replacing `print_tree` with `ErrTreeDisplay`. Also reduces Dependabot frequency to skip bugfix updates.